### PR TITLE
Add bhyve detection

### DIFF
--- a/hypervisor.go
+++ b/hypervisor.go
@@ -11,6 +11,7 @@ import (
 
 // https://en.wikipedia.org/wiki/CPUID#EAX.3D0:_Get_vendor_ID
 var hvmap = map[string]string{
+	"bhyve bhyve ": "bhyve",
 	"KVMKVMKVM":    "kvm",
 	"Microsoft Hv": "hyperv",
 	"VMwareVMware": "vmware",


### PR DESCRIPTION
Heya,

thought I'd say hi, and tell you I swiped your code to make https://github.com/klauspost/cpuid/pull/14

The main reason I didn't just use your code, is that when RancherOS is bootstrapping, not quite enough of the OS is up, and this sysinfo fatal'd out. - cpuid was simpler. I'll circle back later though, as i'm not sure adding dmi to cpuid is the right thing to do.