### PR TITLE
try fallback to use sysfs of DMI block to decode memory info

### DIFF
--- a/memory.go
+++ b/memory.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -125,7 +126,11 @@ func getStructureTableAddress(f *os.File) (address int64, length int, err error)
 func getStructureTable() ([]byte, error) {
 	f, err := os.Open("/dev/mem")
 	if err != nil {
-		return nil, err
+		dmi, err := ioutil.ReadFile("/sys/firmware/dmi/tables/DMI")
+		if err != nil {
+			return nil, err
+		}
+		return dmi, nil
 	}
 	defer f.Close()
 


### PR DESCRIPTION
try to fallback to `/sys/firmware/dmi/tables/DMI` when open `/dev/mem` return `Operation not permitted`