### PR TITLE
Added OS info support for RHEL 6.x

### DIFF
--- a/os.go
+++ b/os.go
@@ -34,6 +34,17 @@ ANSI_COLOR="0;31"
 CPE_NAME="cpe:/o:centos:centos:6"
 HOME_URL="https://www.centos.org/"
 BUG_REPORT_URL="https://bugs.centos.org/"`
+
+	redhat6Template = `NAME="Red Hat Enterprise Linux Server"
+VERSION="%s %s"
+ID="rhel"
+ID_LIKE="fedora"
+VERSION_ID="%s"
+PRETTY_NAME="Red Hat Enterprise Linux"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:redhat:enterprise_linux:%s:GA:server"
+HOME_URL="https://www.redhat.com/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"`
 )
 
 var (
@@ -44,6 +55,7 @@ var (
 	reCentOS     = regexp.MustCompile(`^CentOS( Linux)? release ([\d\.]+) `)
 	reCentOS6    = regexp.MustCompile(`^CentOS release 6\.\d (.*)`)
 	reRedhat     = regexp.MustCompile(`[\( ]([\d\.]+)`)
+	reRedhat6    = regexp.MustCompile(`^Red Hat Enterprise Linux Server release (.*) (.*)`)
 )
 
 func genOSRelease() {
@@ -51,6 +63,24 @@ func genOSRelease() {
 	if release := slurpFile("/etc/centos-release"); release != "" {
 		if m := reCentOS6.FindStringSubmatch(release); m != nil {
 			spewFile(osReleaseFile, fmt.Sprintf(centOS6Template, m[1], m[1]), 0666)
+			return
+		}
+	}
+
+	// RHEL 6.x
+	if release := slurpFile("/etc/redhat-release"); release != "" {
+		if m := reRedhat6.FindStringSubmatch(release); m != nil {
+			version := "6"
+			code_name := "()"
+			switch l := len(m); l {
+			case 3:
+				code_name = m[2]
+				fallthrough
+			case 2:
+				version = m[1]
+			}
+			spewFile(osReleaseFile, fmt.Sprintf(redhat6Template, version, code_name, version, version), 0666)
+			return
 		}
 	}
 }


### PR DESCRIPTION
Changes made in reference to RHEL 7.3 os info files.

```
[admin@RedHat-7 ~]$ cat /etc/redhat-release 
Red Hat Enterprise Linux Server release 7.3 (Maipo)
[admin@RedHat-7 ~]$ 
[admin@RedHat-7 ~]$ cat /etc/os-release 
NAME="Red Hat Enterprise Linux Server"
VERSION="7.3 (Maipo)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="7.3"
PRETTY_NAME="Red Hat Enterprise Linux"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:7.3:GA:server"
HOME_URL="https://www.redhat.com/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
REDHAT_BUGZILLA_PRODUCT_VERSION=7.3
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="7.3"
[admin@RedHat-7 ~]$ 

```