### PR TITLE
Fix go test

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -8,11 +8,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"testing"
 
 	"github.com/zcalusic/sysinfo"
 )
 
-func Example() {
+func Test(t *testing.T) {
 	var si sysinfo.SysInfo
 
 	si.GetSysInfo()


### PR DESCRIPTION
I noticed that `example_test.go` no longer works with newer go version, so I fixed it.