### PR TITLE
Match 'ethtool_cmd' struct layout

### DIFF
--- a/network.go
+++ b/network.go
@@ -66,8 +66,23 @@ func getSupported(name string) uint32 {
 
 	// struct ethtool_cmd from /usr/include/linux/ethtool.h
 	var ethtool struct {
-		Cmd       uint32
-		Supported uint32
+		Cmd            uint32
+		Supported      uint32
+		Advertising    uint32
+		Speed          uint16
+		Duplex         uint8
+		Port           uint8
+		Phy_address    uint8
+		Transceiver    uint8
+		Autoneg        uint8
+		Mdio_support   uint8
+		Maxtxpkt       uint32
+		Maxrxpkt       uint32
+		Speed_hi       uint16
+		Eth_tp_mdix    uint8
+		Reserved2      uint8
+		Lp_advertising uint32
+		Reserved       [2]uint32
 	}
 
 	// ETHTOOL_GSET from /usr/include/linux/ethtool.h


### PR DESCRIPTION
When converting with unsafe.Pointer, the structure that receives data has to be
equivalent in the layout, otherwise it can overflow and panic. To note
this function was deprecated in newer kernels in favor of ethtool_link_settings
( https://github.com/torvalds/linux/commit/3f1ac7a700d039c61d8d8b99f28d605d489a60cf ).

Fixes: https://github.com/zcalusic/sysinfo/issues/29

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>