### PR TITLE
Move information retrieval to each structure

### DIFF
--- a/bios.go
+++ b/bios.go
@@ -11,8 +11,8 @@ type BIOS struct {
 	Date    string `json:"date,omitempty"`
 }
 
-func (si *SysInfo) getBIOSInfo() {
-	si.BIOS.Vendor = slurpFile("/sys/class/dmi/id/bios_vendor")
-	si.BIOS.Version = slurpFile("/sys/class/dmi/id/bios_version")
-	si.BIOS.Date = slurpFile("/sys/class/dmi/id/bios_date")
+func (b *BIOS) GetInfo() {
+	b.Vendor = slurpFile("/sys/class/dmi/id/bios_vendor")
+	b.Version = slurpFile("/sys/class/dmi/id/bios_version")
+	b.Date = slurpFile("/sys/class/dmi/id/bios_date")
 }

--- a/board.go
+++ b/board.go
@@ -13,10 +13,10 @@ type Board struct {
 	AssetTag string `json:"assettag,omitempty"`
 }
 
-func (si *SysInfo) getBoardInfo() {
-	si.Board.Name = slurpFile("/sys/class/dmi/id/board_name")
-	si.Board.Vendor = slurpFile("/sys/class/dmi/id/board_vendor")
-	si.Board.Version = slurpFile("/sys/class/dmi/id/board_version")
-	si.Board.Serial = slurpFile("/sys/class/dmi/id/board_serial")
-	si.Board.AssetTag = slurpFile("/sys/class/dmi/id/board_asset_tag")
+func (b *Board) GetInfo() {
+	b.Name = slurpFile("/sys/class/dmi/id/board_name")
+	b.Vendor = slurpFile("/sys/class/dmi/id/board_vendor")
+	b.Version = slurpFile("/sys/class/dmi/id/board_version")
+	b.Serial = slurpFile("/sys/class/dmi/id/board_serial")
+	b.AssetTag = slurpFile("/sys/class/dmi/id/board_asset_tag")
 }

--- a/chassis.go
+++ b/chassis.go
@@ -15,12 +15,12 @@ type Chassis struct {
 	AssetTag string `json:"assettag,omitempty"`
 }
 
-func (si *SysInfo) getChassisInfo() {
+func (c *Chassis) GetInfo() {
 	if chtype, err := strconv.ParseUint(slurpFile("/sys/class/dmi/id/chassis_type"), 10, 64); err == nil {
-		si.Chassis.Type = uint(chtype)
+		c.Type = uint(chtype)
 	}
-	si.Chassis.Vendor = slurpFile("/sys/class/dmi/id/chassis_vendor")
-	si.Chassis.Version = slurpFile("/sys/class/dmi/id/chassis_version")
-	si.Chassis.Serial = slurpFile("/sys/class/dmi/id/chassis_serial")
-	si.Chassis.AssetTag = slurpFile("/sys/class/dmi/id/chassis_asset_tag")
+	c.Vendor = slurpFile("/sys/class/dmi/id/chassis_vendor")
+	c.Version = slurpFile("/sys/class/dmi/id/chassis_version")
+	c.Serial = slurpFile("/sys/class/dmi/id/chassis_serial")
+	c.AssetTag = slurpFile("/sys/class/dmi/id/chassis_asset_tag")
 }

--- a/cpu.go
+++ b/cpu.go
@@ -31,8 +31,8 @@ var (
 	reCacheSize  = regexp.MustCompile(`^(\d+) KB$`)
 )
 
-func (si *SysInfo) getCPUInfo() {
-	si.CPU.Threads = uint(runtime.NumCPU())
+func (c *CPU) GetInfo(countCPUs bool) {
+	c.Threads = uint(runtime.NumCPU())
 
 	f, err := os.Open("/proc/cpuinfo")
 	if err != nil {
@@ -56,20 +56,20 @@ func (si *SysInfo) getCPUInfo() {
 				coreID := fmt.Sprintf("%s/%s", cpuID, sl[1])
 				core[coreID] = true
 			case "vendor_id":
-				if si.CPU.Vendor == "" {
-					si.CPU.Vendor = sl[1]
+				if c.Vendor == "" {
+					c.Vendor = sl[1]
 				}
 			case "model name":
-				if si.CPU.Model == "" {
+				if c.Model == "" {
 					// CPU model, as reported by /proc/cpuinfo, can be a bit ugly. Clean up...
 					model := reExtraSpace.ReplaceAllLiteralString(sl[1], " ")
-					si.CPU.Model = strings.Replace(model, "- ", "-", 1)
+					c.Model = strings.Replace(model, "- ", "-", 1)
 				}
 			case "cache size":
-				if si.CPU.Cache == 0 {
+				if c.Cache == 0 {
 					if m := reCacheSize.FindStringSubmatch(sl[1]); m != nil {
 						if cache, err := strconv.ParseUint(m[1], 10, 64); err == nil {
-							si.CPU.Cache = uint(cache)
+							c.Cache = uint(cache)
 						}
 					}
 				}
@@ -82,10 +82,10 @@ func (si *SysInfo) getCPUInfo() {
 
 	// getNodeInfo() must have run first, to detect if we're dealing with a virtualized CPU! Detecting number of
 	// physical processors and/or cores is totally unreliable in virtualized environments, so let's not do it.
-	if si.Node.Hostname == "" || si.Node.Hypervisor != "" {
+	if countCPUs {
 		return
 	}
 
-	si.CPU.Cpus = uint(len(cpu))
-	si.CPU.Cores = uint(len(core))
+	c.Cpus = uint(len(cpu))
+	c.Cores = uint(len(core))
 }

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -33,11 +33,11 @@ func getHypervisorCpuid(ax uint32) string {
 	return hvmap[strings.TrimRight(string((*[12]byte)(unsafe.Pointer(&info[1]))[:]), "\000")]
 }
 
-func (si *SysInfo) getHypervisor() {
+func (n *Node) getHypervisor(bios *BIOS) {
 	if !isHypervisorActive() {
 		if hypervisorType := slurpFile("/sys/hypervisor/type"); hypervisorType != "" {
 			if hypervisorType == "xen" {
-				si.Node.Hypervisor = "xenpv"
+				n.Hypervisor = "xenpv"
 			}
 		}
 		return
@@ -46,20 +46,20 @@ func (si *SysInfo) getHypervisor() {
 	// KVM has been caught to move its real signature to this leaf, and put something completely different in the
 	// standard location. So this leaf must be checked first.
 	if hv := getHypervisorCpuid(0x40000100); hv != "" {
-		si.Node.Hypervisor = hv
+		n.Hypervisor = hv
 		return
 	}
 
 	if hv := getHypervisorCpuid(0x40000000); hv != "" {
-		si.Node.Hypervisor = hv
+		n.Hypervisor = hv
 		return
 	}
 
 	// getBIOSInfo() must have run first, to detect BIOS vendor
-	if si.BIOS.Vendor == "Bochs" {
-		si.Node.Hypervisor = "bochs"
+	if bios.Vendor == "Bochs" {
+		n.Hypervisor = "bochs"
 		return
 	}
 
-	si.Node.Hypervisor = "unknown"
+	n.Hypervisor = "unknown"
 }

--- a/kernel.go
+++ b/kernel.go
@@ -17,14 +17,14 @@ type Kernel struct {
 	Architecture string `json:"architecture,omitempty"`
 }
 
-func (si *SysInfo) getKernelInfo() {
-	si.Kernel.Release = slurpFile("/proc/sys/kernel/osrelease")
-	si.Kernel.Version = slurpFile("/proc/sys/kernel/version")
+func (k *Kernel) GetInfo() {
+	k.Release = slurpFile("/proc/sys/kernel/osrelease")
+	k.Version = slurpFile("/proc/sys/kernel/version")
 
 	var uname syscall.Utsname
 	if err := syscall.Uname(&uname); err != nil {
 		return
 	}
 
-	si.Kernel.Architecture = strings.TrimRight(string((*[65]byte)(unsafe.Pointer(&uname.Machine))[:]), "\000")
+	k.Architecture = strings.TrimRight(string((*[65]byte)(unsafe.Pointer(&uname.Machine))[:]), "\000")
 }

--- a/memory.go
+++ b/memory.go
@@ -30,19 +30,19 @@ func qword(data []byte, index int) uint64 {
 	return binary.LittleEndian.Uint64(data[index : index+8])
 }
 
-func (si *SysInfo) getMemoryInfo() {
+func (m *Memory) GetInfo(cpu *CPU) {
 	dmi, err := ioutil.ReadFile("/sys/firmware/dmi/tables/DMI")
 	if err != nil {
 		// Xen hypervisor
 		if targetKB := slurpFile("/sys/devices/system/xen_memory/xen_memory0/target_kb"); targetKB != "" {
-			si.Memory.Type = "DRAM"
+			m.Type = "DRAM"
 			size, _ := strconv.ParseUint(targetKB, 10, 64)
-			si.Memory.Size = uint(size) / 1024
+			m.Size = uint(size) / 1024
 		}
 		return
 	}
 
-	si.Memory.Size = 0
+	m.Size = 0
 	var memSizeAlt uint
 loop:
 	for p := 0; p < len(dmi)-1; {
@@ -51,8 +51,8 @@ loop:
 
 		switch recType {
 		case 4:
-			if si.CPU.Speed == 0 {
-				si.CPU.Speed = uint(word(dmi, p+0x16))
+			if cpu.Speed == 0 {
+				cpu.Speed = uint(word(dmi, p+0x16))
 			}
 		case 17:
 			size := uint(word(dmi, p+0x0c))
@@ -67,9 +67,9 @@ loop:
 				}
 			}
 
-			si.Memory.Size += size
+			m.Size += size
 
-			if si.Memory.Type == "" {
+			if m.Type == "" {
 				// SMBIOS Reference Specification Version 3.0.0, page 92
 				memTypes := [...]string{
 					"Other", "Unknown", "DRAM", "EDRAM", "VRAM", "SRAM", "RAM", "ROM", "FLASH",
@@ -79,13 +79,13 @@ loop:
 				}
 
 				if index := int(dmi[p+0x12]); index >= 1 && index <= len(memTypes) {
-					si.Memory.Type = memTypes[index-1]
+					m.Type = memTypes[index-1]
 				}
 			}
 
-			if si.Memory.Speed == 0 && recLen >= 0x17 {
+			if m.Speed == 0 && recLen >= 0x17 {
 				if speed := uint(word(dmi, p+0x15)); speed != 0 {
-					si.Memory.Speed = speed
+					m.Speed = speed
 				}
 			}
 		case 19:
@@ -114,8 +114,8 @@ loop:
 	}
 
 	// Sometimes DMI type 17 has no information, so we fall back to DMI type 19, to at least get the RAM size.
-	if si.Memory.Size == 0 && memSizeAlt > 0 {
-		si.Memory.Type = "DRAM"
-		si.Memory.Size = memSizeAlt
+	if m.Size == 0 && memSizeAlt > 0 {
+		m.Type = "DRAM"
+		m.Size = memSizeAlt
 	}
 }

--- a/meta.go
+++ b/meta.go
@@ -12,7 +12,7 @@ type Meta struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
-func (si *SysInfo) getMetaInfo() {
-	si.Meta.Version = Version
-	si.Meta.Timestamp = time.Now()
+func (m *Meta) GetInfo() {
+	m.Version = Version
+	m.Timestamp = time.Now()
 }

--- a/network.go
+++ b/network.go
@@ -13,6 +13,9 @@ import (
 	"unsafe"
 )
 
+// Network information.
+type Network []NetworkDevice
+
 // NetworkDevice information.
 type NetworkDevice struct {
 	Name       string `json:"name,omitempty"`
@@ -110,14 +113,13 @@ func getSupported(name string) uint32 {
 	return 0
 }
 
-func (si *SysInfo) getNetworkInfo() {
+func (n *Network) GetInfo() {
 	sysClassNet := "/sys/class/net"
 	devices, err := ioutil.ReadDir(sysClassNet)
 	if err != nil {
 		return
 	}
 
-	si.Network = make([]NetworkDevice, 0)
 	for _, link := range devices {
 		fullpath := path.Join(sysClassNet, link.Name())
 		dev, err := os.Readlink(fullpath)
@@ -142,6 +144,6 @@ func (si *SysInfo) getNetworkInfo() {
 			device.Driver = path.Base(driver)
 		}
 
-		si.Network = append(si.Network, device)
+		*n = append(*n, device)
 	}
 }

--- a/os.go
+++ b/os.go
@@ -29,12 +29,12 @@ var (
 	reRedHat     = regexp.MustCompile(`[\( ]([\d\.]+)`)
 )
 
-func (si *SysInfo) getOSInfo() {
+func (o *OS) GetInfo() {
 	// This seems to be the best and most portable way to detect OS architecture (NOT kernel!)
 	if _, err := os.Stat("/lib64/ld-linux-x86-64.so.2"); err == nil {
-		si.OS.Architecture = "amd64"
+		o.Architecture = "amd64"
 	} else if _, err := os.Stat("/lib/ld-linux.so.2"); err == nil {
-		si.OS.Architecture = "i386"
+		o.Architecture = "i386"
 	}
 
 	f, err := os.Open("/etc/os-release")
@@ -46,36 +46,36 @@ func (si *SysInfo) getOSInfo() {
 	s := bufio.NewScanner(f)
 	for s.Scan() {
 		if m := rePrettyName.FindStringSubmatch(s.Text()); m != nil {
-			si.OS.Name = strings.Trim(m[1], `"`)
+			o.Name = strings.Trim(m[1], `"`)
 		} else if m := reID.FindStringSubmatch(s.Text()); m != nil {
-			si.OS.Vendor = strings.Trim(m[1], `"`)
+			o.Vendor = strings.Trim(m[1], `"`)
 		} else if m := reVersionID.FindStringSubmatch(s.Text()); m != nil {
-			si.OS.Version = strings.Trim(m[1], `"`)
+			o.Version = strings.Trim(m[1], `"`)
 		}
 	}
 
-	switch si.OS.Vendor {
+	switch o.Vendor {
 	case "debian":
-		si.OS.Release = slurpFile("/etc/debian_version")
+		o.Release = slurpFile("/etc/debian_version")
 	case "ubuntu":
-		if m := reUbuntu.FindStringSubmatch(si.OS.Name); m != nil {
-			si.OS.Release = m[1]
+		if m := reUbuntu.FindStringSubmatch(o.Name); m != nil {
+			o.Release = m[1]
 		}
 	case "centos":
 		if release := slurpFile("/etc/centos-release"); release != "" {
 			if m := reCentOS.FindStringSubmatch(release); m != nil {
-				si.OS.Release = m[2]
+				o.Release = m[2]
 			}
 		}
 	case "rhel":
 		if release := slurpFile("/etc/redhat-release"); release != "" {
 			if m := reRedHat.FindStringSubmatch(release); m != nil {
-				si.OS.Release = m[1]
+				o.Release = m[1]
 			}
 		}
-		if si.OS.Release == "" {
-			if m := reRedHat.FindStringSubmatch(si.OS.Name); m != nil {
-				si.OS.Release = m[1]
+		if o.Release == "" {
+			if m := reRedHat.FindStringSubmatch(o.Name); m != nil {
+				o.Release = m[1]
 			}
 		}
 	}

--- a/product.go
+++ b/product.go
@@ -12,9 +12,9 @@ type Product struct {
 	Serial  string `json:"serial,omitempty"`
 }
 
-func (si *SysInfo) getProductInfo() {
-	si.Product.Name = slurpFile("/sys/class/dmi/id/product_name")
-	si.Product.Vendor = slurpFile("/sys/class/dmi/id/sys_vendor")
-	si.Product.Version = slurpFile("/sys/class/dmi/id/product_version")
-	si.Product.Serial = slurpFile("/sys/class/dmi/id/product_serial")
+func (p *Product) GetInfo() {
+	p.Name = slurpFile("/sys/class/dmi/id/product_name")
+	p.Vendor = slurpFile("/sys/class/dmi/id/sys_vendor")
+	p.Version = slurpFile("/sys/class/dmi/id/product_version")
+	p.Serial = slurpFile("/sys/class/dmi/id/product_serial")
 }

--- a/storage.go
+++ b/storage.go
@@ -13,6 +13,9 @@ import (
 	"strings"
 )
 
+// Storage information.
+type Storage []StorageDevice
+
 // StorageDevice information.
 type StorageDevice struct {
 	Name   string `json:"name,omitempty"`
@@ -58,14 +61,13 @@ scan:
 	return
 }
 
-func (si *SysInfo) getStorageInfo() {
+func (s *Storage) GetInfo() {
 	sysBlock := "/sys/block"
 	devices, err := ioutil.ReadDir(sysBlock)
 	if err != nil {
 		return
 	}
 
-	si.Storage = make([]StorageDevice, 0)
 	for _, link := range devices {
 		fullpath := path.Join(sysBlock, link.Name())
 		dev, err := os.Readlink(fullpath)
@@ -100,6 +102,6 @@ func (si *SysInfo) getStorageInfo() {
 		size, _ := strconv.ParseUint(slurpFile(path.Join(fullpath, "size")), 10, 64)
 		device.Size = uint(size) / 1953125 // GiB
 
-		si.Storage = append(si.Storage, device)
+		*s = append(*s, device)
 	}
 }

--- a/sysinfo.go
+++ b/sysinfo.go
@@ -7,43 +7,43 @@ package sysinfo
 
 // SysInfo struct encapsulates all other information structs.
 type SysInfo struct {
-	Meta    Meta            `json:"sysinfo"`
-	Node    Node            `json:"node"`
-	OS      OS              `json:"os"`
-	Kernel  Kernel          `json:"kernel"`
-	Product Product         `json:"product"`
-	Board   Board           `json:"board"`
-	Chassis Chassis         `json:"chassis"`
-	BIOS    BIOS            `json:"bios"`
-	CPU     CPU             `json:"cpu"`
-	Memory  Memory          `json:"memory"`
-	Storage []StorageDevice `json:"storage,omitempty"`
-	Network []NetworkDevice `json:"network,omitempty"`
+	Meta    Meta    `json:"sysinfo"`
+	Node    Node    `json:"node"`
+	OS      OS      `json:"os"`
+	Kernel  Kernel  `json:"kernel"`
+	Product Product `json:"product"`
+	Board   Board   `json:"board"`
+	Chassis Chassis `json:"chassis"`
+	BIOS    BIOS    `json:"bios"`
+	CPU     CPU     `json:"cpu"`
+	Memory  Memory  `json:"memory"`
+	Storage Storage `json:"storage,omitempty"`
+	Network Network `json:"network,omitempty"`
 }
 
 // GetSysInfo gathers all available system information.
 func (si *SysInfo) GetSysInfo() {
 	// Meta info
-	si.getMetaInfo()
+	si.Meta.GetInfo()
 
 	// DMI info
-	si.getProductInfo()
-	si.getBoardInfo()
-	si.getChassisInfo()
-	si.getBIOSInfo()
+	si.Product.GetInfo()
+	si.Board.GetInfo()
+	si.Chassis.GetInfo()
+	si.BIOS.GetInfo()
 
 	// SMBIOS info
-	si.getMemoryInfo()
+	si.Memory.GetInfo(&si.CPU)
 
 	// Node info
-	si.getNodeInfo() // depends on BIOS info
+	si.Node.GetInfo(&si.BIOS)
 
 	// Hardware info
-	si.getCPUInfo() // depends on Node info
-	si.getStorageInfo()
-	si.getNetworkInfo()
+	si.CPU.GetInfo(si.Node.Hostname != "" && si.Node.Hypervisor == "")
+	si.Storage.GetInfo()
+	si.Network.GetInfo()
 
 	// Software info
-	si.getOSInfo()
-	si.getKernelInfo()
+	si.OS.GetInfo()
+	si.Kernel.GetInfo()
 }


### PR DESCRIPTION
Right now, it is not possible to use the library to get only a subset of the information.
This PR adds a `GetInfo` method to every member of the `SysInfo` struct to allow it.
It also has the advantage on making the ordering requirements a bit clearer.