### PR TITLE
support building on darwin

### DIFF
--- a/kernel_darwin.go
+++ b/kernel_darwin.go
@@ -1,0 +1,13 @@
+//+build darwin
+
+package sysinfo
+
+// Kernel information.
+type Kernel struct {
+	Release      string `json:"release,omitempty"`
+	Version      string `json:"version,omitempty"`
+	Architecture string `json:"architecture,omitempty"`
+}
+
+func (si *SysInfo) getKernelInfo() {
+}

--- a/kernel_linux.go
+++ b/kernel_linux.go
@@ -2,6 +2,8 @@
 //
 // Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 
+//+build linux
+
 package sysinfo
 
 import (


### PR DESCRIPTION
With just making go only build the linux part on linux and providing a file for darwin that will return an empty Kernle, this should support building sysinfo under darwin systems

Signed-off-by: Itxaka <igarcia@suse.com>