### PR TITLE
Test on github CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,20 @@
+name: Test
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        version: [1.15, 1.16, 1.17]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.version }}
+      - run: go build
+      - run: go test


### PR DESCRIPTION
Use a matrix to test the different combinations of system and go
version

This allows us to test both on linux and macos easily.

Requires https://github.com/zcalusic/sysinfo/pull/35 to pass the darwin part of course :D

Signed-off-by: Itxaka <igarcia@suse.com>