### PR TITLE
refactor code

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,7 @@ func main() {
 		log.Fatal("requires superuser privilege")
 	}
 
-	var si sysinfo.SysInfo
-
-	si.GetSysInfo()
+	si := sysinfo.GetSysInfo()
 
 	data, err := json.MarshalIndent(&si, "", "  ")
 	if err != nil {

--- a/bios.go
+++ b/bios.go
@@ -11,8 +11,10 @@ type BIOS struct {
 	Date    string `json:"date,omitempty"`
 }
 
-func (si *SysInfo) getBIOSInfo() {
-	si.BIOS.Vendor = slurpFile("/sys/class/dmi/id/bios_vendor")
-	si.BIOS.Version = slurpFile("/sys/class/dmi/id/bios_version")
-	si.BIOS.Date = slurpFile("/sys/class/dmi/id/bios_date")
+func GetBIOSInfo() BIOS {
+	return BIOS{
+		Vendor:  slurpFile("/sys/class/dmi/id/bios_vendor"),
+		Version: slurpFile("/sys/class/dmi/id/bios_version"),
+		Date:    slurpFile("/sys/class/dmi/id/bios_date"),
+	}
 }

--- a/board.go
+++ b/board.go
@@ -13,10 +13,12 @@ type Board struct {
 	AssetTag string `json:"assettag,omitempty"`
 }
 
-func (si *SysInfo) getBoardInfo() {
-	si.Board.Name = slurpFile("/sys/class/dmi/id/board_name")
-	si.Board.Vendor = slurpFile("/sys/class/dmi/id/board_vendor")
-	si.Board.Version = slurpFile("/sys/class/dmi/id/board_version")
-	si.Board.Serial = slurpFile("/sys/class/dmi/id/board_serial")
-	si.Board.AssetTag = slurpFile("/sys/class/dmi/id/board_asset_tag")
+func GetBoardInfo() Board {
+	return Board{
+		Name:     slurpFile("/sys/class/dmi/id/board_name"),
+		Vendor:   slurpFile("/sys/class/dmi/id/board_vendor"),
+		Version:  slurpFile("/sys/class/dmi/id/board_version"),
+		Serial:   slurpFile("/sys/class/dmi/id/board_serial"),
+		AssetTag: slurpFile("/sys/class/dmi/id/board_asset_tag"),
+	}
 }

--- a/chassis.go
+++ b/chassis.go
@@ -15,12 +15,13 @@ type Chassis struct {
 	AssetTag string `json:"assettag,omitempty"`
 }
 
-func (si *SysInfo) getChassisInfo() {
-	if chtype, err := strconv.ParseUint(slurpFile("/sys/class/dmi/id/chassis_type"), 10, 64); err == nil {
-		si.Chassis.Type = uint(chtype)
+func GetChassisInfo() Chassis {
+	chassisType, _ := strconv.ParseUint(slurpFile("/sys/class/dmi/id/chassis_type"), 10, 64)
+	return Chassis{
+		Type:     uint(chassisType),
+		Vendor:   slurpFile("/sys/class/dmi/id/chassis_vendor"),
+		Version:  slurpFile("/sys/class/dmi/id/chassis_version"),
+		Serial:   slurpFile("/sys/class/dmi/id/chassis_serial"),
+		AssetTag: slurpFile("/sys/class/dmi/id/chassis_asset_tag"),
 	}
-	si.Chassis.Vendor = slurpFile("/sys/class/dmi/id/chassis_vendor")
-	si.Chassis.Version = slurpFile("/sys/class/dmi/id/chassis_version")
-	si.Chassis.Serial = slurpFile("/sys/class/dmi/id/chassis_serial")
-	si.Chassis.AssetTag = slurpFile("/sys/class/dmi/id/chassis_asset_tag")
 }

--- a/cmd/sysinfo/main.go
+++ b/cmd/sysinfo/main.go
@@ -26,9 +26,7 @@ func main() {
 		log.Fatal("requires superuser privilege")
 	}
 
-	var si sysinfo.SysInfo
-
-	si.GetSysInfo()
+	si := sysinfo.GetSysInfo()
 
 	data, err := json.MarshalIndent(&si, "", "  ")
 	if err != nil {

--- a/kernel.go
+++ b/kernel.go
@@ -1,0 +1,8 @@
+package sysinfo
+
+// Kernel information.
+type Kernel struct {
+	Release      string `json:"release,omitempty"`
+	Version      string `json:"version,omitempty"`
+	Architecture string `json:"architecture,omitempty"`
+}

--- a/kernel_darwin.go
+++ b/kernel_darwin.go
@@ -1,13 +1,8 @@
-//+build darwin
+//go:build darwin
+// +build darwin
 
 package sysinfo
 
-// Kernel information.
-type Kernel struct {
-	Release      string `json:"release,omitempty"`
-	Version      string `json:"version,omitempty"`
-	Architecture string `json:"architecture,omitempty"`
-}
-
-func (si *SysInfo) getKernelInfo() {
+func GetKernelInfo() Kernel {
+	return Kernel{}
 }

--- a/kernel_linux.go
+++ b/kernel_linux.go
@@ -2,7 +2,8 @@
 //
 // Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 
-//+build linux
+//go:build linux
+// +build linux
 
 package sysinfo
 
@@ -12,21 +13,16 @@ import (
 	"unsafe"
 )
 
-// Kernel information.
-type Kernel struct {
-	Release      string `json:"release,omitempty"`
-	Version      string `json:"version,omitempty"`
-	Architecture string `json:"architecture,omitempty"`
-}
-
-func (si *SysInfo) getKernelInfo() {
-	si.Kernel.Release = slurpFile("/proc/sys/kernel/osrelease")
-	si.Kernel.Version = slurpFile("/proc/sys/kernel/version")
+func GetKernelInfo() Kernel {
+	kernelInfo := Kernel{}
+	kernelInfo.Release = slurpFile("/proc/sys/kernel/osrelease")
+	kernelInfo.Version = slurpFile("/proc/sys/kernel/version")
 
 	var uname syscall.Utsname
 	if err := syscall.Uname(&uname); err != nil {
-		return
+		return kernelInfo
 	}
 
-	si.Kernel.Architecture = strings.TrimRight(string((*[65]byte)(unsafe.Pointer(&uname.Machine))[:]), "\000")
+	kernelInfo.Architecture = strings.TrimRight(string((*[65]byte)(unsafe.Pointer(&uname.Machine))[:]), "\000")
+	return kernelInfo
 }

--- a/meta.go
+++ b/meta.go
@@ -12,7 +12,9 @@ type Meta struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
-func (si *SysInfo) getMetaInfo() {
-	si.Meta.Version = Version
-	si.Meta.Timestamp = time.Now()
+func GetMetaInfo() Meta {
+	return Meta{
+		Version:   Version,
+		Timestamp: time.Now(),
+	}
 }

--- a/network.go
+++ b/network.go
@@ -110,14 +110,14 @@ func getSupported(name string) uint32 {
 	return 0
 }
 
-func (si *SysInfo) getNetworkInfo() {
+func GetNetworkInfo() []NetworkDevice {
 	sysClassNet := "/sys/class/net"
 	devices, err := ioutil.ReadDir(sysClassNet)
 	if err != nil {
-		return
+		return nil
 	}
 
-	si.Network = make([]NetworkDevice, 0)
+	networkDevices := make([]NetworkDevice, 0)
 	for _, link := range devices {
 		fullpath := path.Join(sysClassNet, link.Name())
 		dev, err := os.Readlink(fullpath)
@@ -142,6 +142,7 @@ func (si *SysInfo) getNetworkInfo() {
 			device.Driver = path.Base(driver)
 		}
 
-		si.Network = append(si.Network, device)
+		networkDevices = append(networkDevices, device)
 	}
+	return networkDevices
 }

--- a/product.go
+++ b/product.go
@@ -12,9 +12,11 @@ type Product struct {
 	Serial  string `json:"serial,omitempty"`
 }
 
-func (si *SysInfo) getProductInfo() {
-	si.Product.Name = slurpFile("/sys/class/dmi/id/product_name")
-	si.Product.Vendor = slurpFile("/sys/class/dmi/id/sys_vendor")
-	si.Product.Version = slurpFile("/sys/class/dmi/id/product_version")
-	si.Product.Serial = slurpFile("/sys/class/dmi/id/product_serial")
+func GetProductInfo() Product {
+	return Product{
+		Name:    slurpFile("/sys/class/dmi/id/product_name"),
+		Vendor:  slurpFile("/sys/class/dmi/id/sys_vendor"),
+		Version: slurpFile("/sys/class/dmi/id/product_version"),
+		Serial:  slurpFile("/sys/class/dmi/id/product_serial"),
+	}
 }

--- a/storage.go
+++ b/storage.go
@@ -58,14 +58,13 @@ scan:
 	return
 }
 
-func (si *SysInfo) getStorageInfo() {
+func GetStorageInfo() []StorageDevice {
 	sysBlock := "/sys/block"
 	devices, err := ioutil.ReadDir(sysBlock)
 	if err != nil {
-		return
+		return nil
 	}
-
-	si.Storage = make([]StorageDevice, 0)
+	storages := make([]StorageDevice, 0)
 	for _, link := range devices {
 		fullpath := path.Join(sysBlock, link.Name())
 		dev, err := os.Readlink(fullpath)
@@ -100,6 +99,7 @@ func (si *SysInfo) getStorageInfo() {
 		size, _ := strconv.ParseUint(slurpFile(path.Join(fullpath, "size")), 10, 64)
 		device.Size = uint(size) / 1953125 // GiB
 
-		si.Storage = append(si.Storage, device)
+		storages = append(storages, device)
 	}
+	return storages
 }

--- a/sysinfo.go
+++ b/sysinfo.go
@@ -22,28 +22,34 @@ type SysInfo struct {
 }
 
 // GetSysInfo gathers all available system information.
-func (si *SysInfo) GetSysInfo() {
+func GetSysInfo() SysInfo {
+	si := SysInfo{}
 	// Meta info
-	si.getMetaInfo()
+	si.Meta = GetMetaInfo()
 
 	// DMI info
-	si.getProductInfo()
-	si.getBoardInfo()
-	si.getChassisInfo()
-	si.getBIOSInfo()
+	si.Product = GetProductInfo()
+	si.Board = GetBoardInfo()
+	si.Chassis = GetChassisInfo()
+	si.BIOS = GetBIOSInfo()
 
 	// SMBIOS info
-	si.getMemoryInfo()
+	si.Memory, si.CPU.Speed = GetMemoryInfoAndCPUSpeed()
 
 	// Node info
-	si.getNodeInfo() // depends on BIOS info
+	si.Node = GetNodeInfo(si.BIOS.Vendor)
 
 	// Hardware info
-	si.getCPUInfo() // depends on Node info
-	si.getStorageInfo()
-	si.getNetworkInfo()
+
+	// we need to detect if we're dealing with a virtualized CPU! Detecting number of
+	// physical processors and/or cores is totally unreliable in virtualized environments, so let's not do it.
+	virtualEnv := si.Node.Hostname == "" || si.Node.Hypervisor != ""
+	si.CPU = GetCPUInfo(virtualEnv)
+	si.Storage = GetStorageInfo()
+	si.Network = GetNetworkInfo()
 
 	// Software info
-	si.getOSInfo()
-	si.getKernelInfo()
+	si.OS = GetOSInfo()
+	si.Kernel = GetKernelInfo()
+	return si
 }


### PR DESCRIPTION
Now we can call `sysinfo.GetCPUInfo` to get cpu info instead of getting a full `SysInfo` which contains extra information that we don't need. This make `sysinfo` more flexible.