### PR TITLE
Fix CentOS Release Regex

### DIFF
--- a/os.go
+++ b/os.go
@@ -25,7 +25,7 @@ var (
 	reID         = regexp.MustCompile(`^ID=(.*)$`)
 	reVersionID  = regexp.MustCompile(`^VERSION_ID=(.*)$`)
 	reUbuntu     = regexp.MustCompile(`[\( ]([\d\.]+)`)
-	reCentOS     = regexp.MustCompile(`^CentOS( Linux)? release ([\d\.]+) `)
+	reCentOS     = regexp.MustCompile(`^CentOS( Linux)? release ([\d\.]+)`)
 	reRedHat     = regexp.MustCompile(`[\( ]([\d\.]+)`)
 )
 


### PR DESCRIPTION
There is a whitespace at the end of the current regex that breaks the CentOS Release. The fix has been tested on CentOS from version 7.0 to 8.4 using docker containers.