### PR TITLE
Do not write files in user system

### DIFF
--- a/node.go
+++ b/node.go
@@ -6,11 +6,8 @@ package sysinfo
 
 import (
 	"bufio"
-	"crypto/rand"
-	"fmt"
 	"os"
 	"strings"
-	"time"
 )
 
 // Node information.
@@ -58,19 +55,6 @@ func (si *SysInfo) getSetMachineID() {
 		si.Node.MachineID = systemdMachineID
 		return
 	}
-
-	// Generate and write fresh new machine ID to both locations, conforming to the DBUS specification:
-	// https://dbus.freedesktop.org/doc/dbus-specification.html#uuids
-
-	random := make([]byte, 12)
-	if _, err := rand.Read(random); err != nil {
-		return
-	}
-	newMachineID := fmt.Sprintf("%x%x", random, time.Now().Unix())
-
-	spewFile(pathSystemdMachineID, newMachineID, 0444)
-	spewFile(pathDbusMachineID, newMachineID, 0444)
-	si.Node.MachineID = newMachineID
 }
 
 func (si *SysInfo) getTimezone() {


### PR DESCRIPTION
This stops sysinfo from writing files in the running system without telling the user about it.

A system with no machine-id is a completely valid system and can be like that at different times, like inside a container, on a first boot, in immutable systems, etc...

We should not write files in teh user system without informing them and not having a machine-id is a valid state.

Fixes: https://github.com/zcalusic/sysinfo/issues/42