### PR TITLE
fallback to device-tree when DMI informations are not available to fetch serial product

### DIFF
--- a/product.go
+++ b/product.go
@@ -27,4 +27,18 @@ func (si *SysInfo) getProductInfo() {
 	if err == nil {
 		si.Product.UUID = uid
 	}
+
+	// try a fallback to device-tree (ex: dmi is not available on ARM devices)
+	// full details: https://www.devicetree.org/specifications/
+
+	// on linux root path is /proc/device-tree (see: https://github.com/torvalds/linux/blob/v5.9/Documentation/ABI/testing/sysfs-firmware-ofw)
+	if si.Product.Name == "" {
+		si.Product.Name = slurpFile("/proc/device-tree/model")
+	}
+
+	if si.Product.Serial == "" {
+		si.Product.Serial = slurpFile("/proc/device-tree/serial-number")
+	}
+
+
 }

--- a/util.go
+++ b/util.go
@@ -16,7 +16,8 @@ func slurpFile(path string) string {
 		return ""
 	}
 
-	return strings.TrimSpace(string(data))
+	// Trim spaces & \u0000 \uffff
+	return strings.Trim( string(data), " \r\n\t\u0000\uffff")
 }
 
 // Write one-liner text files, add newline, ignore errors (best effort).


### PR DESCRIPTION
Please find a fallback to device-tree norm when DMI informations are not available

more details: 
- https://www.kernel.org/doc/html/latest/devicetree/usage-model.html
- https://www.devicetree.org/specifications/

I only added informations on `Product` section, device-tree may be usable on other additional devices

Example on an old  R-Pi device:
Before:
```
$ sudo ./sysinfo | jq -r .product
{
  "uuid": "00000000-0000-0000-0000-000000000000"
}
```

After:
```
$ sudo ./sysinfo | jq -r .product
{
  "name": "Raspberry Pi 3 Model B Rev 1.2",
  "serial": "00000000279****",
  "uuid": "00000000-0000-0000-0000-000000000000"
}
``` 
